### PR TITLE
Added support for Gallaxy Tab as an Android Tablet

### DIFF
--- a/PHP/mdetect.php
+++ b/PHP/mdetect.php
@@ -85,6 +85,7 @@ class uagent_info
    var $deviceGoogleTV = 'googletv';
    var $deviceXoom = 'xoom'; //Motorola Xoom
    var $deviceHtcFlyer = 'htc_flyer'; //HTC Flyer
+   var $deviceGalaxyTab = 'sch-i800'; // Galaxy Tab
    
    var $deviceWinPhone7 = 'windows phone os 7'; 
    var $deviceWinPhone8 = 'windows phone 8'; 
@@ -364,7 +365,10 @@ class uagent_info
          return $this->false; 
       //Special check for the HTC Flyer 7" tablet. It should NOT report here.
       if ((stripos($this->useragent, $this->deviceHtcFlyer) > -1))
-         return $this->false; 
+         return $this->false;
+      //Special check for Galaxy Tab which is a tablet but contains 'Mobile' in the UA string
+      if ((stripos($this->useragent, $this->deviceGalaxyTab) > -1))
+         return $this->true;
          
       //Otherwise, if it's Android and does NOT have 'mobile' in it, Google says it's a tablet.
       if (stripos($this->useragent, $this->mobile) > -1)


### PR DESCRIPTION
The previous advice from Google: http://googlewebmastercentral.blogspot.com/2011/03/mo-better-to-also-detect-mobile-user.html Is incorrect now. Some Android tablets do include the word 'mobile' in their user agent string.

**Galaxy Tab User Agent String:** _(Note the presence of the 'mobile' keyword.)_

```
Mozilla/5.0 (Linux; U; Android 2.2; en-us; SCH-I800 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
```

**Some responses from the community:**
http://stackoverflow.com/questions/5341637/how-do-detect-android-tablets-in-general-useragent

However, Galaxy was kind enough to add the device model number to the UA, 'SCH-I800' which we're able to test against.
