### PR TITLE
Buf Fix with DetectMobileQuick() in mdetect.php

### DIFF
--- a/PHP/mdetect.php
+++ b/PHP/mdetect.php
@@ -1086,7 +1086,8 @@ class uagent_info
          return $this->isMobilePhone;
 
       //Let's exclude tablets
-      if ($this->isTierTablet == $this->true) 
+      // Jesse Heap Patch: Prior code was using $this->isTierTablet which isn't set when running this the first time.  Changed to DetectTierTablet which sets $this->isTierTablet
+      if ($this->DetectTierTablet() == $this->true) 
          return $this->false;
       
       //Most mobile browsing is done on smartphones

--- a/PHP/mdetect.php
+++ b/PHP/mdetect.php
@@ -4,7 +4,7 @@
 // Copyright 2010-2015, Anthony Hand
 //
 //
-// File version 2015.05.13 (May 13, 2015)
+// File version 2016.07.23 (July 23, 2016)
 // Updates:
 //	- Moved MobileESP to GitHub. https://github.com/ahand/mobileesp
 //	- Opera Mobile/Mini browser has the same UA string on multiple platforms and doesn't differentiate phone vs. tablet. 


### PR DESCRIPTION
Prior code on line 1089 for mdetect.php was using $this->isTierTablet which isn't set when running this the first time.  Changed to DetectTierTablet which sets $this->isTierTablet
